### PR TITLE
Work around for U# compiler error with U# 0.x

### DIFF
--- a/Scripts/DFUNC/DFUNC_Flares.cs
+++ b/Scripts/DFUNC/DFUNC_Flares.cs
@@ -49,7 +49,7 @@ public class DFUNC_Flares : UdonSharpBehaviour
         func_active = false;
         if (SequentialLaunch)
         {
-            _SendLaunchFlare = -1;
+            _SendLaunchFlare = (short)-1;
             RequestSerialization();
         }
     }
@@ -68,7 +68,7 @@ public class DFUNC_Flares : UdonSharpBehaviour
     {
         if (SequentialLaunch)
         {
-            _SendLaunchFlare = -1;
+            _SendLaunchFlare = (short)-1;
             RequestSerialization();
         }
     }
@@ -77,7 +77,7 @@ public class DFUNC_Flares : UdonSharpBehaviour
         func_active = false;
         if (SequentialLaunch)
         {
-            _SendLaunchFlare = -1;
+            _SendLaunchFlare = (short)-1;
             RequestSerialization();
         }
     }
@@ -193,7 +193,7 @@ public class DFUNC_Flares : UdonSharpBehaviour
     {
         if (sendlaunchflare == 0)
         {
-            sendlaunchflare = -1;
+            sendlaunchflare = (short)-1;
             RequestSerialization();
         }
     }


### PR DESCRIPTION
These lines will cause an error when compiling U#.

Can't wait for the 1.0 release...