### PR TITLE
Add Assembly Definition

### DIFF
--- a/Scripts/SaccFlightAndVehicles.Runtime.asmdef
+++ b/Scripts/SaccFlightAndVehicles.Runtime.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "SaccFlightAndVehicles.Runtime",
+    "references": [
+        "GUID:3c1bc1267eab5884ebe7f232c09ee0d9",
+        "GUID:99835874ee819da44948776e0df4ff1d"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UDON",
+        "VRC_SDK_VRCSDK3"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Scripts/SaccFlightAndVehicles.Runtime.asmdef.meta
+++ b/Scripts/SaccFlightAndVehicles.Runtime.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 823e7b1dbeb8b2a4c9d5014bf2a39093
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/SaccFlightAndVehicles.Runtime.asset
+++ b/Scripts/SaccFlightAndVehicles.Runtime.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5136146375e9a0a498a72a0091b40cc1, type: 3}
+  m_Name: SaccFlightAndVehicles.Runtime
+  m_EditorClassIdentifier: 
+  sourceAssembly: {fileID: 5897886265953266890, guid: 823e7b1dbeb8b2a4c9d5014bf2a39093,
+    type: 3}

--- a/Scripts/SaccFlightAndVehicles.Runtime.asset.meta
+++ b/Scripts/SaccFlightAndVehicles.Runtime.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 535cba3c689fcda429f8520af9edca0b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
It allows other libraries that reference SaccFlight to use the Assembly Definition.
It also makes the binaries to be compiled independent and faster to compile.

Docs: https://docs.unity.cn/2019.4/Documentation/Manual/ScriptCompilationAssemblyDefinitionFiles.html

One thing to note is that we need to edit the Assembly Definition when using external scripts.
![image](https://user-images.githubusercontent.com/2088693/147874811-0a110bae-8e1c-4ca3-b013-0eada613d848.png)
