### PR TITLE
Add ZeroLiftAoA to SaccAirVehicle

### DIFF
--- a/Scripts/SaccAirVehicle/SaccAirVehicle.cs
+++ b/Scripts/SaccAirVehicle/SaccAirVehicle.cs
@@ -150,6 +150,8 @@ namespace SaccFlightAndVehicles
         public float HighPitchAoaMinLift = 0.2f;
         [Tooltip("See above")]
         public float HighYawAoaMinLift = 0.2f;
+        [Tooltip("The angle at which the aircraft's wings produce zero lift. Influenced by the wing's camber angle. A larger camber usually results in a lower ZeroLiftAoA. Helps simulate the plane's natural glide. Usually a negative value.")]
+        public float ZeroLiftAoA = 0f;
         [Tooltip("Degrees per second the vehicle rotates on the ground. Uses simple object rotation with a lerp, no real physics to it.")]
         public float TaxiRotationSpeed = 35f;
         [Tooltip("How lerped the taxi movement rotation is")]
@@ -2239,7 +2241,7 @@ namespace SaccFlightAndVehicles
             AirVel = VehicleRigidbody.velocity - (FinalWind * StillWindMulti);
             AirSpeed = AirVel.magnitude;
             Vector3 VecForward = VehicleTransform.forward;
-            AngleOfAttackPitch = Vector3.SignedAngle(VecForward, Vector3.ProjectOnPlane(AirVel, VehicleTransform.right), VehicleTransform.right);
+            AngleOfAttackPitch = Vector3.SignedAngle(VecForward, Vector3.ProjectOnPlane(AirVel, VehicleTransform.right), VehicleTransform.right) - ZeroLiftAoA;
             AngleOfAttackYaw = Vector3.SignedAngle(VecForward, Vector3.ProjectOnPlane(AirVel, VehicleTransform.up), VehicleTransform.up);
             //angle of attack stuff, pitch and yaw are calculated seperately
             //pitch and yaw each have a curve for when they are within the 'MaxAngleOfAttack' and a linear version up to 90 degrees, which are Max'd (using Mathf.Clamp) for the final result.


### PR DESCRIPTION
Adding a new aircraft parameter `ZeroLiftAoA` (Zero Lift Angle of Attack). This parameter presents the angle of attack (AoA) at which the aircraft wings generate zero lift. It simply offsets the calculated pitch AoA.

The `ZeroLiftAoA` parameter is usually negative value of degrees. It is also affected by the camber angle of the wing, and generally the higher the camber, the smaller the `ZeroLiftAoA`. This feature allows for better representation of wing shape differences between aircraft models.

Especially for aircraft with low engine power, adjusting this `ZeroLiftAoA` parameter is expected to improve takeoff behavior.